### PR TITLE
fix(typing): add tsdef to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "test:watch": "jest --watch"
   },
   "pre-commit": "precommit",
+  "dependencies": {
+    "tsdef": "^0.0.14"
+  },
   "peerDependencies": {
     "graphql": "*",
     "tslib": "^1.10.0"
@@ -69,7 +72,6 @@
     "prettier": "^1.19.1",
     "ts-jest": "^24.1.0",
     "tscpaths": "^0.0.9",
-    "tsdef": "^0.0.13",
     "tslint": "^5.20.1",
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3642,10 +3642,10 @@ tscpaths@^0.0.9:
     commander "^2.20.0"
     globby "^9.2.0"
 
-tsdef@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.npmjs.org/tsdef/-/tsdef-0.0.13.tgz#c71c2bd756c84887386ac8539ace63a38bc114e1"
-  integrity sha512-Twcdol23BQ+J+WD3NYhqusB7vvCDdK2bvcXnivgHu4xjrxnngUshgB+SWs2FN+I6BxY6BRkaE2KllO403GwbKA==
+tsdef@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/tsdef/-/tsdef-0.0.14.tgz#fb401d58d5c08699091942981ac1b5fa8ef23412"
+  integrity sha512-UjMD4XKRWWFlFBfwKVQmGFT5YzW/ZaF8x6KpCDf92u9wgKeha/go3FU0e5WqDjXsCOdfiavCkfwfVHNDxRDGMA==
 
 tslib@1.9.0:
   version "1.9.0"


### PR DESCRIPTION
`tsdef` package is needed by projects using `graphql-scalar` so it needs to be either in `dependencies` or `peerDependencies`

As this package is not as common as `graphql` and `tslib`, I figured it would be better to add it as a normal dependency.

If you prefer to have it in `peerDependencies` @joonhocho  l can do the update

Fixes #4 